### PR TITLE
Fix for issue #1

### DIFF
--- a/VMware/remove-allocations.ps1
+++ b/VMware/remove-allocations.ps1
@@ -5,7 +5,7 @@
 
 # Pull in vars
 $vars = (Get-Item $PSScriptRoot).Parent.FullName + "\vars.ps1"
-Invoke-Expression ($vars)
+Invoke-Expression ($vars -replace ' ', '` ')
 
 ### Import modules
 Add-PSSnapin -Name VMware.VimAutomation.Core

--- a/VMware/remove-media.ps1
+++ b/VMware/remove-media.ps1
@@ -5,7 +5,7 @@
 
 # Pull in vars
 $vars = (Get-Item $PSScriptRoot).Parent.FullName + "\vars.ps1"
-Invoke-Expression ($vars)
+Invoke-Expression ($vars -replace ' ', '` ')
 
 ### Import modules
 Add-PSSnapin -Name VMware.VimAutomation.Core

--- a/VMware/set-dns.ps1
+++ b/VMware/set-dns.ps1
@@ -5,7 +5,7 @@
 
 # Pull in vars
 $vars = (Get-Item $PSScriptRoot).Parent.FullName + "\vars.ps1"
-Invoke-Expression ($vars)
+Invoke-Expression ($vars -replace ' ', '` ')
 
 ### Import modules or snapins
 $powercli = Get-PSSnapin -Name VMware.VimAutomation.Core -Registered

--- a/VMware/set-drs.ps1
+++ b/VMware/set-drs.ps1
@@ -4,7 +4,7 @@
 
 # Pull in vars
 $vars = (Get-Item $PSScriptRoot).Parent.FullName + "\vars.ps1"
-Invoke-Expression ($vars)
+Invoke-Expression ($vars -replace ' ', '` ')
 
 ### Import modules
 Add-PSSnapin -Name VMware.VimAutomation.Core

--- a/VMware/set-nfsconfig.ps1
+++ b/VMware/set-nfsconfig.ps1
@@ -5,7 +5,7 @@
 
 # Pull in vars
 $vars = (Get-Item $PSScriptRoot).Parent.FullName + '\vars.ps1'
-Invoke-Expression ($vars)
+Invoke-Expression ($vars -replace ' ', '` ')
 
 ### Import modules or snapins
 $powercli = Get-PSSnapin -Name VMware.VimAutomation.Core -Registered

--- a/VMware/set-ssh.ps1
+++ b/VMware/set-ssh.ps1
@@ -5,7 +5,7 @@
 
 # Pull in vars
 $vars = (Get-Item $PSScriptRoot).Parent.FullName + "\vars.ps1"
-Invoke-Expression ($vars)
+Invoke-Expression ($vars -replace ' ', '` ')
 
 ### Import modules
 Add-PSSnapin -Name VMware.VimAutomation.Core

--- a/VMware/set-syslog.ps1
+++ b/VMware/set-syslog.ps1
@@ -5,7 +5,7 @@
 
 # Pull in vars
 $vars = (Get-Item $PSScriptRoot).Parent.FullName + "\vars.ps1"
-Invoke-Expression ($vars)
+Invoke-Expression ($vars -replace ' ', '` ')
 
 ### Import modules
 Add-PSSnapin -Name VMware.VimAutomation.Core

--- a/Windows/Update-TemplateVM.ps1
+++ b/Windows/Update-TemplateVM.ps1
@@ -4,7 +4,7 @@
 
 # Pull in vars
 $vars = (Get-Item $PSScriptRoot).Parent.FullName + "\vars.ps1"
-Invoke-Expression ($vars)
+Invoke-Expression ($vars -replace ' ', '` ')
 
 # Add the required modules
 Import-Module PSWindowsUpdate


### PR DESCRIPTION
This fix correct the issue #1.

Invoke-Expression does not handle correctly paths with space in it. One of the solution is to escaping spaces with a backtick like for example:

```PowerShell
# Pull in vars
$vars = (Get-Item $PSScriptRoot).Parent.FullName + "\vars.ps1"
Invoke-Expression ($vars -replace ' ', '` ')
```
